### PR TITLE
Add back "back-reference" calculation

### DIFF
--- a/.github/workflows/s3-to-github.yml
+++ b/.github/workflows/s3-to-github.yml
@@ -38,6 +38,11 @@ on: # yamllint disable-line rule:truthy
         required: false
         default: true
         type: boolean
+      sync-back-references:
+        description: "Sync generated back-references to S3"
+        required: false
+        default: true
+        type: boolean
       processes:
         description: "Number of processes to use for syncing"
         required: false
@@ -52,6 +57,8 @@ jobs:
       DOCUMENT_PACKAGES: ${{ inputs.document-packages }}
       COMMIT_CHANGES: ${{ inputs.commit-changes }}
       PROCESSES: ${{ inputs.processes }}
+      AIRFLOW_SITE_DIRECTORY:  /mnt/cloned-airflow-site-archive
+
     steps:
       - name: Summarize parameters
         id: parameters
@@ -160,11 +167,58 @@ jobs:
             --processes "${PROCESSES}"
         working-directory: /mnt/cloned-airflow-site-archive
 
+      - uses: actions/checkout@v4
+        # Checkout airflow to run breeze
+        with:
+          repository: 'apache/airflow'
+          path: airflow
+          fetch-depth: 1
+
+      - name: "Install breeze"
+        run: uv tool install -e ./dev/breeze
+        working-directory: airflow
+
+      - name: "Generate back references for providers"
+        run: breeze release-management add-back-references all-providers
+        working-directory: airflow
+
+      - name: "Generate back references for apache-airflow"
+        run: breeze release-management add-back-references apache-airflow
+        working-directory: airflow
+
+      - name: "Generate back references for docker-stack"
+        run: breeze release-management add-back-references docker-stack
+        working-directory: airflow
+
+      - name: "Generate back references for helm-chart"
+        run: breeze release-management add-back-references helm-chart
+        working-directory: airflow
+
       - name: Show files that will be committed
         run : git add --dry-run .
         working-directory: /mnt/cloned-airflow-site-archive
 
-      - name: Committing changes
+      - name: Syncing back-reference changes to ${{ inputs.source }} (${{ inputs.document-packages }})
+        env:
+          PROCESSES: ${{ inputs.processes }}
+          DOCUMENT_PACKAGES: ${{ inputs.document-packages }}
+          SOURCE_LOCATION: ${{ steps.parameters.outputs.source-location }}
+        run: |
+          set -x
+          aws configure set default.s3.max_concurrent_requests 10
+          uv run ./scripts/github_to_s3.py \
+            --bucket-path ${SOURCE_LOCATION} \
+            --local-path /mnt/cloned-airflow-site-archive/docs-archive \
+            --document-packages "${DOCUMENTS_PACKAGES}" \
+            --commit-ref "main" --sync-type full-sync --skip-delete \
+            --processes ${PROCESSES}
+        working-directory: /mnt/cloned-airflow-site-archive
+        if: >
+          inputs.sync-back-references == true && (
+             github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging'
+          ) && inputs.commit-changes == true
+
+      - name: Committing live changes
         run: |
           echo "Running git config"
           git config user.name "GitHub Actions"
@@ -175,4 +229,17 @@ jobs:
           git commit -m "Sync S3 to GitHub" || echo -e "\e[32mNo changes to commit\e[0m"
           git push --force origin main
         working-directory: /mnt/cloned-airflow-site-archive
-        if: inputs.commit-changes == true && github.ref == 'refs/heads/main'
+        if: inputs.commit-changes == true && github.ref == 'refs/heads/main' && inputs.source == 'live'
+
+      - name: Committing staging changes
+        run: |
+          echo "Running git config"
+          git config user.name "GitHub Actions"
+          git config user.email "actions@users.noreply.github.com"
+          echo "Running git add"
+          git add --verbose .
+          echo "Running git commit"
+          git commit -m "Sync S3 to GitHub" || echo -e "\e[32mNo changes to commit\e[0m"
+          git push --force origin main
+        working-directory: /mnt/cloned-airflow-site-archive
+        if: inputs.commit-changes == true && github.ref == 'refs/heads/staging' && inputs.source == 'staging'

--- a/scripts/github_to_s3.py
+++ b/scripts/github_to_s3.py
@@ -91,7 +91,7 @@ class GithubToS3(CommonTransferUtils):
         self.run_with_pool(self.remove, delete_files_pool_args, processes=processes)
         self.run_with_pool(self.copy, copy_files_pool_args, processes=processes)
 
-    def full_sync(self, processes: int, packages: list[str] | None = None):
+    def full_sync(self, processes: int, packages: list[str] | None = None, skip_delete: bool = False):
         if packages:
             console.print(f"[blue] Syncing packages {packages} from {self.local_path} to {self.bucket_name} [/]")
         else:
@@ -101,7 +101,7 @@ class GithubToS3(CommonTransferUtils):
         for package in sort_priority_packages(list_of_packages):
             source = os.path.join(self.local_path, package)
             dest = f"s3://{self.bucket_name}/{self.prefix}".rstrip("/") + "/" + package
-            pool_args.append((source, dest))
+            pool_args.append((source, dest, skip_delete))
 
         self.run_with_pool(self.sync, pool_args, processes=processes)
 
@@ -118,6 +118,7 @@ if __name__ == "__main__":
     parser.add_argument("--sync-type", help="Sync type", choices=('full-sync', 'single-commit'),
                         default="single-commit")
     parser.add_argument("--processes", help="Number of processes", type=int, default=8)
+    parser.add_argument("--skip-delete", help="Skip deleting missing files", action='store_true')
 
     args = parser.parse_args()
 
@@ -147,9 +148,10 @@ if __name__ == "__main__":
             else:
                 console.print(f"[red] Document package {full_local_path} does not exist.[/]")
                 sys.exit(1)
-        syncer.full_sync(processes=int(args.processes), packages=packages_to_sync)
+        syncer.full_sync(processes=int(args.processes), packages=packages_to_sync,
+                         skip_delete=args.skip_delete)
     elif args.sync_type == "full-sync":
-        syncer.full_sync(processes=int(args.processes))
+        syncer.full_sync(processes=int(args.processes), skip_delete=args.skip_delete)
     elif args.sync_type == "single-commit" and args.commit_ref and document_packages == "all":
         console.print(f"[blue] Syncing last commit {args.commit_ref} from {args.local_path} [/]")
         syncer.sync_single_commit_files(args.commit_ref, processes=int(args.processes))

--- a/scripts/transfer_utils.py
+++ b/scripts/transfer_utils.py
@@ -78,20 +78,21 @@ class CommonTransferUtils:
             return []
 
 
-    def sync(self, source: str, destination: str):
+    def sync(self, source: str, destination: str, skip_delete: bool = False):
         console.print(f"{source}[yellow] Sync started to   [/]{destination}")
         with tempfile.NamedTemporaryFile(mode="w+", delete=True, suffix=".out") as output_file:
             thread = Thread(target=track_progress, args=(source, Path(output_file.name),))
             thread.start()
+            delete= ["--delete"] if not skip_delete else []
             if source.startswith("s3://"):
                 subprocess.run(
-                    ["aws", "s3", "sync", "--delete", "--no-progress", source, destination],
+                    ["aws", "s3", "sync", *delete, "--no-progress", source, destination],
                     stdout=output_file,
                     text=True, check=True
                 )
             elif Path(source).is_dir():
                 subprocess.run(
-                    ["aws", "s3", "sync", "--delete",  "--no-progress", source, destination],
+                    ["aws", "s3", "sync", *delete,  "--no-progress", source, destination],
                     stdout=output_file,
                     text=True, check=True
                 )


### PR DESCRIPTION
I've removed back-reference calculation from airflow "Push docs to S3" workflow - because it is not really possible to add back-references there - as they are added in the "other" versions of the distribution not in the current one - so when we release latest "3.0.2", back references should be added in all other versions. This - therefore should be done whenever we perform s3-to-github push from main in the `airflow-site-archive` - because this is the place where we update github based on s3 content and where we locally have all past versions of the packages we work on.