### PR TITLE
Update constraints references for 2.11

### DIFF
--- a/docs-archive/apache-airflow/2.11.0/installation/installing-from-pypi.html
+++ b/docs-archive/apache-airflow/2.11.0/installation/installing-from-pypi.html
@@ -745,7 +745,7 @@ the problem in <a class="reference external" href="https://github.com/bazelbuild
 newer versions of <code class="docutils literal notranslate"><span class="pre">bazel</span></code> will handle it.</p>
 </div>
 <p>Typical command to install airflow from scratch in a reproducible way from PyPI looks like below:</p>
-<div class="highlight-bash notranslate"><div class="highlight"><pre><span></span>pip<span class="w"> </span>install<span class="w"> </span><span class="s2">&quot;apache-airflow[celery]==2.11.0&quot;</span><span class="w"> </span>--constraint<span class="w"> </span><span class="s2">&quot;https://raw.githubusercontent.com/apache/airflow/constraints-2.11.0/constraints-3.8.txt&quot;</span>
+<div class="highlight-bash notranslate"><div class="highlight"><pre><span></span>pip<span class="w"> </span>install<span class="w"> </span><span class="s2">&quot;apache-airflow[celery]==2.11.0&quot;</span><span class="w"> </span>--constraint<span class="w"> </span><span class="s2">&quot;https://raw.githubusercontent.com/apache/airflow/constraints-2.11.0/constraints-3.9.txt&quot;</span>
 </pre></div>
 </div>
 <p>Typically, you can add other dependencies and providers as separate command after the reproducible
@@ -800,7 +800,7 @@ constraints file for each version of Python that Airflow supports.</p>
 </ul>
 <p>The examples below assume that you want to use install airflow in a reproducible way with the <code class="docutils literal notranslate"><span class="pre">celery</span></code> extra,
 but you can pick your own set of extras and providers to install.</p>
-<div class="highlight-bash notranslate"><div class="highlight"><pre><span></span>pip<span class="w"> </span>install<span class="w"> </span><span class="s2">&quot;apache-airflow[celery]==2.11.0&quot;</span><span class="w"> </span>--constraint<span class="w"> </span><span class="s2">&quot;https://raw.githubusercontent.com/apache/airflow/constraints-2.11.0/constraints-3.8.txt&quot;</span>
+<div class="highlight-bash notranslate"><div class="highlight"><pre><span></span>pip<span class="w"> </span>install<span class="w"> </span><span class="s2">&quot;apache-airflow[celery]==2.11.0&quot;</span><span class="w"> </span>--constraint<span class="w"> </span><span class="s2">&quot;https://raw.githubusercontent.com/apache/airflow/constraints-2.11.0/constraints-3.9.txt&quot;</span>
 </pre></div>
 </div>
 <div class="admonition note">
@@ -825,13 +825,13 @@ reasons. Installing such dependencies should be done without constraints as a se
 packages to install and pin it to the version that you have, otherwise you might end up with a
 different version of Airflow than you expect because <code class="docutils literal notranslate"><span class="pre">pip</span></code> can upgrade/downgrade it automatically when
 performing dependency resolution.</p>
-<div class="highlight-bash notranslate"><div class="highlight"><pre><span></span>pip<span class="w"> </span>install<span class="w"> </span><span class="s2">&quot;apache-airflow[celery]==2.11.0&quot;</span><span class="w"> </span>--constraint<span class="w"> </span><span class="s2">&quot;https://raw.githubusercontent.com/apache/airflow/constraints-2.11.0/constraints-3.8.txt&quot;</span>
+<div class="highlight-bash notranslate"><div class="highlight"><pre><span></span>pip<span class="w"> </span>install<span class="w"> </span><span class="s2">&quot;apache-airflow[celery]==2.11.0&quot;</span><span class="w"> </span>--constraint<span class="w"> </span><span class="s2">&quot;https://raw.githubusercontent.com/apache/airflow/constraints-2.11.0/constraints-3.9.txt&quot;</span>
 pip<span class="w"> </span>install<span class="w"> </span><span class="s2">&quot;apache-airflow==2.11.0&quot;</span><span class="w"> </span>apache-airflow-providers-google<span class="o">==</span><span class="m">10</span>.1.1
 </pre></div>
 </div>
 <p>You can also downgrade or upgrade other dependencies this way - even if they are not compatible with
 those dependencies that are stored in the original constraints file:</p>
-<div class="highlight-bash notranslate"><div class="highlight"><pre><span></span>pip<span class="w"> </span>install<span class="w"> </span><span class="s2">&quot;apache-airflow[celery]==2.11.0&quot;</span><span class="w"> </span>--constraint<span class="w"> </span><span class="s2">&quot;https://raw.githubusercontent.com/apache/airflow/constraints-2.11.0/constraints-3.8.txt&quot;</span>
+<div class="highlight-bash notranslate"><div class="highlight"><pre><span></span>pip<span class="w"> </span>install<span class="w"> </span><span class="s2">&quot;apache-airflow[celery]==2.11.0&quot;</span><span class="w"> </span>--constraint<span class="w"> </span><span class="s2">&quot;https://raw.githubusercontent.com/apache/airflow/constraints-2.11.0/constraints-3.9.txt&quot;</span>
 pip<span class="w"> </span>install<span class="w"> </span><span class="s2">&quot;apache-airflow[celery]==2.11.0&quot;</span><span class="w"> </span>dbt-core<span class="o">==</span><span class="m">0</span>.20.0
 </pre></div>
 </div>
@@ -865,7 +865,7 @@ conflicting dependencies in your environment.</p>
 to continue being able to keep reproducible installation of Airflow and those dependencies via a single command.
 In order to do that, you can produce your own constraints file and use it to install Airflow instead of the
 one provided by the community.</p>
-<div class="highlight-bash notranslate"><div class="highlight"><pre><span></span>pip<span class="w"> </span>install<span class="w"> </span><span class="s2">&quot;apache-airflow[celery]==2.11.0&quot;</span><span class="w"> </span>--constraint<span class="w"> </span><span class="s2">&quot;https://raw.githubusercontent.com/apache/airflow/constraints-2.11.0/constraints-3.8.txt&quot;</span>
+<div class="highlight-bash notranslate"><div class="highlight"><pre><span></span>pip<span class="w"> </span>install<span class="w"> </span><span class="s2">&quot;apache-airflow[celery]==2.11.0&quot;</span><span class="w"> </span>--constraint<span class="w"> </span><span class="s2">&quot;https://raw.githubusercontent.com/apache/airflow/constraints-2.11.0/constraints-3.9.txt&quot;</span>
 pip<span class="w"> </span>install<span class="w"> </span><span class="s2">&quot;apache-airflow==2.11.0&quot;</span><span class="w"> </span>dbt-core<span class="o">==</span><span class="m">0</span>.20.0
 pip<span class="w"> </span>freeze<span class="w"> </span>&gt;<span class="w"> </span>my-constraints.txt
 </pre></div>

--- a/docs-archive/apache-airflow/2.11.0/start.html
+++ b/docs-archive/apache-airflow/2.11.0/start.html
@@ -683,7 +683,7 @@ constraint files to enable reproducible installation, so using <code class="docu
 <span class="nv">PYTHON_VERSION</span><span class="o">=</span><span class="s2">&quot;</span><span class="k">$(</span>python<span class="w"> </span>-c<span class="w"> </span><span class="s1">&#39;import sys; print(f&quot;{sys.version_info.major}.{sys.version_info.minor}&quot;)&#39;</span><span class="k">)</span><span class="s2">&quot;</span>
 
 <span class="nv">CONSTRAINT_URL</span><span class="o">=</span><span class="s2">&quot;https://raw.githubusercontent.com/apache/airflow/constraints-</span><span class="si">${</span><span class="nv">AIRFLOW_VERSION</span><span class="si">}</span><span class="s2">/constraints-</span><span class="si">${</span><span class="nv">PYTHON_VERSION</span><span class="si">}</span><span class="s2">.txt&quot;</span>
-<span class="c1"># For example this would install 2.11.0 with python 3.8: https://raw.githubusercontent.com/apache/airflow/constraints-2.11.0/constraints-3.8.txt</span>
+<span class="c1"># For example this would install 2.11.0 with python 3.8: https://raw.githubusercontent.com/apache/airflow/constraints-2.11.0/constraints-3.9.txt</span>
 
 pip<span class="w"> </span>install<span class="w"> </span><span class="s2">&quot;apache-airflow==</span><span class="si">${</span><span class="nv">AIRFLOW_VERSION</span><span class="si">}</span><span class="s2">&quot;</span><span class="w"> </span>--constraint<span class="w"> </span><span class="s2">&quot;</span><span class="si">${</span><span class="nv">CONSTRAINT_URL</span><span class="si">}</span><span class="s2">&quot;</span>
 </pre></div>


### PR DESCRIPTION
We don't have Python 3.8 in Airflow 2.11

This it to fix the public docs, a PR to fix it also in airflow 2.11 test branch will follow