### PR TITLE
Harden GH Actions workflows: pinned SHAs, zizmor, dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,41 @@
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+---
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    cooldown:
+      default-days: 4
+    directory: /
+    schedule:
+      interval: daily
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+  - package-ecosystem: pre-commit
+    cooldown:
+      default-days: 4
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      pre-commit-hooks:
+        patterns:
+          - "*"

--- a/.github/workflows/asf-allowlist-check.yml
+++ b/.github/workflows/asf-allowlist-check.yml
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+---
+name: "ASF Allowlist Check"
+"on":
+  pull_request:
+    paths: [".github/**"]
+  push:
+    branches: [main]
+    paths: [".github/**"]
+permissions:
+  contents: read
+jobs:
+  asf-allowlist-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: apache/infrastructure-actions/allowlist-check@70ab74bb5ccc96bb2b9bc51404f1f09cfb909aec  # main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,11 @@ on:
     branches: ['main']
   pull_request:
   workflow_dispatch:
-
+permissions:
+  contents: read
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   lint:
     name: "Lint the repository"
@@ -19,12 +23,13 @@ jobs:
       - name: "Install uv"
         run: curl -LsSf https://astral.sh/uv/install.sh | sh
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} ) for scripts"
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         # Checkout only workflow and scripts directory to run scripts from
         with:
           sparse-checkout: |
             .github
             scripts
+          persist-credentials: false
       - name: 🔎 Lint
         run: |
           uv tool install pre-commit --with pre-commit-uv

--- a/.github/workflows/github-to-s3.yml
+++ b/.github/workflows/github-to-s3.yml
@@ -53,8 +53,13 @@ on: # yamllint disable-line rule:truthy
         required: false
         default: "4"
         type: string
+permissions:
+  contents: read
+concurrency:
+  group: github-to-s3-${{ github.ref }}-${{ inputs.destination }}
+  cancel-in-progress: false
 jobs:
-  github-to-s3:
+  github-to-s3:  # zizmor: ignore[secrets-outside-env]
     name: GitHub to S3
     runs-on: ubuntu-latest
     steps:
@@ -87,14 +92,15 @@ jobs:
           else
             echo "sync-type=single-commit" >> ${GITHUB_OUTPUT}
           fi
-          echo "commit-ref=${{ env.COMMIT_REFERENCE }}" >> ${GITHUB_OUTPUT}
+          echo "commit-ref=${COMMIT_REFERENCE}" >> ${GITHUB_OUTPUT}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         # Checkout only workflow and scripts directory to run scripts from
         with:
           sparse-checkout: |
             .github
             scripts
+          persist-credentials: false
 
       - name: Install AWS CLI v2
         run: |
@@ -105,7 +111,7 @@ jobs:
           rm -rf /tmp/aws/
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a  # v4.0.1
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7  # v6.0.0
         with:
           aws-access-key-id: ${{ secrets.DOCS_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.DOCS_AWS_SECRET_ACCESS_KEY }}
@@ -119,12 +125,13 @@ jobs:
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
 
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} ) for scripts"
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         # Checkout only workflow and scripts directory to run scripts from
         with:
           sparse-checkout: |
             .github
             scripts
+          persist-credentials: false
 
       - name: Create /mnt/cloned-airflow-site-archive directory
         run: |
@@ -166,21 +173,23 @@ jobs:
       - name: >
           Checkout (${{  steps.parameters.outputs.commit-ref }}) to /mnt/cloned-airflow-site-archive
           with docs packages: ${{ steps.docs-packages-processed.outputs.docs-packages-processed }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           path: ./cloned-airflow-site-archive
           fetch-depth: 2
           sparse-checkout: |
             ${{ steps.docs-packages-processed.outputs.sparse-checkout }}
           ref: ${{ steps.parameters.outputs.commit-ref }}
+          persist-credentials: false
         if: steps.docs-packages-processed.outputs.docs-packages-processed != 'all'
       - name: >
           Checkout (${{  steps.parameters.outputs.commit-ref }}) to /mnt/cloned-airflow-site-archive (all packages)
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           path: ./cloned-airflow-site-archive
           fetch-depth: 2
           ref: ${{ steps.parameters.outputs.commit-ref }}
+          persist-credentials: false
         if: steps.docs-packages-processed.outputs.docs-packages-processed == 'all'
       - name: "Install uv"
         run: curl -LsSf https://astral.sh/uv/install.sh | sh

--- a/.github/workflows/s3-to-github.yml
+++ b/.github/workflows/s3-to-github.yml
@@ -53,10 +53,17 @@ on: # yamllint disable-line rule:truthy
         required: false
         default: "4"
         type: string
+permissions:
+  contents: read
+concurrency:
+  group: s3-to-github-${{ github.ref }}-${{ inputs.source }}
+  cancel-in-progress: false
 jobs:
-  s3-to-github:
+  s3-to-github:  # zizmor: ignore[secrets-outside-env]
     name: S3 to GitHub
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # push synced docs back to main/staging branches
     env:
       SOURCE: ${{ inputs.source }}
       DOCUMENT_PACKAGES: ${{ inputs.document-packages }}
@@ -94,7 +101,7 @@ jobs:
           rm -rf /tmp/aws/
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a  # v4.0.1
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7  # v6.0.0
         with:
           aws-access-key-id: ${{ secrets.DOCS_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.DOCS_AWS_SECRET_ACCESS_KEY }}
@@ -141,20 +148,22 @@ jobs:
       - name: >
           Checkout (${{  inputs.commit-sha || github.sha }}) to /mnt/cloned-airflow-site-archive
           with docs: ${{ steps.docs-packages-processed.outputs.docs-packages-processed }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           path: ./cloned-airflow-site-archive
           fetch-depth: 1
           sparse-checkout: |
             ${{ steps.docs-packages-processed.outputs.sparse-checkout }}
+          persist-credentials: true
         if: steps.docs-packages-processed.outputs.docs-packages-processed != 'all'
 
       - name: >
           Checkout (${{  inputs.commit-sha || github.sha }}) to /mnt/cloned-airflow-site-archive (whole repo)
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           path: ./cloned-airflow-site-archive
           fetch-depth: 1
+          persist-credentials: true
         if: steps.docs-packages-processed.outputs.docs-packages-processed == 'all'
 
       - name: "Check space available"
@@ -184,12 +193,13 @@ jobs:
         working-directory: /mnt/cloned-airflow-site-archive
         if: inputs.sync-registry == true
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         # Checkout airflow to run breeze
         with:
           repository: 'apache/airflow'
           path: airflow
           fetch-depth: 1
+          persist-credentials: false
 
       - name: "Install breeze"
         run: uv tool install -e ./dev/breeze

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,15 @@ repos:
     hooks:
       - id: check-hooks-apply
       - id: check-useless-excludes
+  - repo: https://github.com/woodruffw/zizmor-pre-commit
+    rev: ea2eb407b4cbce87cf0d502f36578950494f5ac9  # frozen: v1.23.1
+    hooks:
+      - id: zizmor
+        name: Run zizmor to check for github workflow syntax errors
+        types: [yaml]
+        files: ^\.github/workflows/.*$|^\.github/actions/.*$
+        require_serial: true
+        entry: zizmor
   - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.3.1
     hooks:


### PR DESCRIPTION
## Summary

Brings airflow-site-archive workflow hygiene up to the same bar as airflow-site:

- **Pinned SHAs** — all `actions/*` and `aws-actions/*` usages pinned to commit SHAs with version comments (matches airflow-site's pins: `actions/checkout@v6.0.2`, `aws-actions/configure-aws-credentials@v6.0.0`).
- **Permissions** — explicit `permissions:` blocks on every workflow. Default is `contents: read`; `s3-to-github` adds job-level `contents: write` (with a comment) for the push back to `main`/`staging`.
- **Concurrency** — concurrency groups added to all three sync/lint workflows.
- **persist-credentials** — `persist-credentials: false` on every checkout except the ones `s3-to-github` actually commits from.
- **Template-injection fix** — `github-to-s3.yml` `Summarize parameters` step no longer interpolates `${{ env.COMMIT_REFERENCE }}` directly into a shell heredoc (flagged by zizmor).
- **zizmor pre-commit hook** — added the same `woodruffw/zizmor-pre-commit` hook pinned to v1.23.1 that airflow-site uses.
- **Dependabot** — new `.github/dependabot.yml` covering `github-actions` (daily) and `pre-commit` (weekly), both with 4-day cooldown and grouped updates, matching airflow-site / apache/airflow conventions.
- **ASF allowlist check** — new `asf-allowlist-check.yml` using `apache/infrastructure-actions/allowlist-check` pinned to latest `main` (`70ab74bb5ccc96bb2b9bc51404f1f09cfb909aec`).

`zizmor .github/workflows/` now reports **no findings** (both default and `--pedantic` modes, aside from the same `secrets-outside-env` suppressions airflow-site already uses).

## Test plan

- [ ] CI lint job passes on this PR
- [ ] ASF allowlist check runs and passes
- [ ] Dependabot opens its first scheduled run after merge
- [ ] Trigger `Sync GitHub to S3` (staging) to confirm the v6 checkout + v6 aws-credentials still work
- [ ] Trigger `Sync S3 to GitHub` (staging) to confirm the push-back still works with the job-level `contents: write`

🤖 Generated with [Claude Code](https://claude.com/claude-code)