### PR TITLE
Tighten dependabot cooldown and bump security pre-commit hooks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,7 +21,7 @@ version: 2
 updates:
   - package-ecosystem: github-actions
     cooldown:
-      default-days: 4
+      default-days: 7
     directory: /
     schedule:
       interval: daily
@@ -31,7 +31,7 @@ updates:
           - "*"
   - package-ecosystem: pre-commit
     cooldown:
-      default-days: 4
+      default-days: 7
     directory: /
     schedule:
       interval: weekly

--- a/.github/workflows/asf-allowlist-check.yml
+++ b/.github/workflows/asf-allowlist-check.yml
@@ -32,4 +32,4 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
-      - uses: apache/infrastructure-actions/allowlist-check@70ab74bb5ccc96bb2b9bc51404f1f09cfb909aec  # main
+      - uses: apache/infrastructure-actions/allowlist-check@4e9c961f587f72b170874b6f5cd4ac15f7f26eb8  # main

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
       - id: check-hooks-apply
       - id: check-useless-excludes
   - repo: https://github.com/woodruffw/zizmor-pre-commit
-    rev: ea2eb407b4cbce87cf0d502f36578950494f5ac9  # frozen: v1.23.1
+    rev: a4727cbbcd26d7098e96b9cb738169b59711ae51  # frozen: v1.24.1
     hooks:
       - id: zizmor
         name: Run zizmor to check for github workflow syntax errors
@@ -35,7 +35,7 @@ repos:
         require_serial: true
         entry: zizmor
   - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.3.1
+    rev: ad1b27d73581aa16cca06fc4a0761fc563ffe8e8  # frozen: v1.5.6
     hooks:
       - id: forbid-tabs
   - repo: local
@@ -50,7 +50,7 @@ repos:
         require_serial: true
         additional_dependencies: ['ruff']
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # frozen: v6.0.0
     hooks:
       - id: check-merge-conflict
       - id: detect-private-key


### PR DESCRIPTION
## Summary
- Bump dependabot `cooldown.default-days` from 4 → 7 across `github-actions` and `pre-commit` ecosystems.
- Refresh `apache/infrastructure-actions/allowlist-check` pin (`70ab74bb…` → `4e9c961f…`) to match `apache/airflow`.
- Bump pre-commit hooks to the same frozen SHA pins used in `apache/airflow-site`:
  - `zizmor-pre-commit` v1.23.1 → v1.24.1
  - `Lucas-C/pre-commit-hooks` v1.3.1 → v1.5.6
  - `pre-commit/pre-commit-hooks` v4.4.0 → v6.0.0
- All workflow action pins (`actions/checkout` v6.0.2, `aws-actions/configure-aws-credentials` v6.1.0) are already at the latest allowed versions — no changes needed.

## Test plan
- [ ] CI passes on this PR (Basic checks + ASF Allowlist Check workflows)