### PR TITLE
Run dependabot against staging branch as well as main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,10 +29,32 @@ updates:
       github-actions:
         patterns:
           - "*"
+  - package-ecosystem: github-actions
+    cooldown:
+      default-days: 7
+    directory: /
+    target-branch: staging
+    schedule:
+      interval: daily
+    groups:
+      github-actions:
+        patterns:
+          - "*"
   - package-ecosystem: pre-commit
     cooldown:
       default-days: 7
     directory: /
+    schedule:
+      interval: weekly
+    groups:
+      pre-commit-hooks:
+        patterns:
+          - "*"
+  - package-ecosystem: pre-commit
+    cooldown:
+      default-days: 7
+    directory: /
+    target-branch: staging
     schedule:
       interval: weekly
     groups:


### PR DESCRIPTION
## Summary
- Duplicate the `github-actions` and `pre-commit` ecosystem entries in `.github/dependabot.yml` with `target-branch: staging` so the `staging` branch receives the same dependency bumps as `main`.
- Cooldown, schedule, and grouping settings match the existing `main` entries so the two branches stay in lockstep.

## Test plan
- [ ] Merge and verify Dependabot opens PRs targeting both `main` and `staging` for the next github-actions/pre-commit update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)